### PR TITLE
Workflow import of single/secondary layer path fixed (#266)

### DIFF
--- a/src/main/java/com/gw/tools/WorkflowTool.java
+++ b/src/main/java/com/gw/tools/WorkflowTool.java
@@ -851,12 +851,20 @@ public class WorkflowTool {
 
 		foldername = foldername.substring(0, foldername.lastIndexOf("."));
 
-		String workflowjson = bt.readStringFromFile(bt.getFileTransferFolder() + foldername + FileSystems.getDefault().getSeparator() + "workflow.json");
-	
-		String codefolder = bt.getFileTransferFolder() + foldername + FileSystems.getDefault().getSeparator() + "code"+ FileSystems.getDefault().getSeparator();
+		String folder_path = bt.getFileTransferFolder() + foldername + FileSystems.getDefault().getSeparator();
 
-		String historyfolder = bt.getFileTransferFolder() + foldername + FileSystems.getDefault().getSeparator() + "history"+ FileSystems.getDefault().getSeparator();
+		File checkanotherlayer = new File(folder_path + foldername + FileSystems.getDefault().getSeparator());
 
+		if (checkanotherlayer.exists())
+			folder_path += foldername + FileSystems.getDefault().getSeparator();
+
+
+		String workflowjson = bt.readStringFromFile(folder_path + "workflow.json");
+
+		String codefolder = folder_path + "code" + FileSystems.getDefault().getSeparator();
+
+		String historyfolder = folder_path + "history" + FileSystems.getDefault().getSeparator();
+		
 		//save workflow
 		Workflow w = this.fromJSON(workflowjson);
 


### PR DESCRIPTION
Manual testing for importing a workflow with a single or secondary folder structure is now working. `WorkflowTest.java` was executed, all test cases passed, and an overall run of all test cases passed with the latest modifications. Fix for #266